### PR TITLE
Only allow annotating of elements with 'annotatable' classname + bump to v1.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recogito-js",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "A JavaScript library for text annotation",
   "main": "dist/recogito.min.js",
   "files": [

--- a/src/selection/SelectionHandler.js
+++ b/src/selection/SelectionHandler.js
@@ -73,10 +73,11 @@ export default class SelectionHandler extends EventEmitter {
       } else if (!this.readOnly) {
         const selectedRange = trimRange(selection.getRangeAt(0));
 
-        // Make sure the selection is entirely inside this.el
         const { commonAncestorContainer } = selectedRange;
+        const isAnnotatable = selectedRange.startContainer.parentNode.classList?.contains('annotatable')
 
-        if (contains(this.el, commonAncestorContainer)) {
+        // Ensure that the selection is marked as annotatable and is entirely inside this.el
+        if (isAnnotatable && contains(this.el, commonAncestorContainer)) {
           const stub = rangeToSelection(selectedRange, this.el);
 
           const spans = this.highlighter.wrapRange(selectedRange);


### PR DESCRIPTION
JIRA Key: https://pathlighthq.atlassian.net/browse/FUJ-2128

The `startContainer` is always a text node (the text that you're highlighting) and we check the parent node since it's the wrapper of message:
```html
<div id="annotatable-container">
    <div id="content-0">
        <h5>don't want to annotate</h5>
        <span class="annotatable">
            want to annotate  <!-- Highlighting 'ant', startContainer is this text node, so move up 1 -->
        </span> 
    </div>
    <div id="content-1">
        <h5>don't want to annotate</h5>
        <span class="annotatable">want to annotate</span>
    </div>
    ...
</div>
```