### PR TITLE
Include creator in annotation instead of each body

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recogito-js",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "A JavaScript library for text annotation",
   "main": "dist/recogito.min.js",
   "files": [

--- a/src/TextAnnotator.jsx
+++ b/src/TextAnnotator.jsx
@@ -379,7 +379,8 @@ export default class TextAnnotator extends Component {
             onAnnotationCreated={this.onCreateOrUpdateAnnotation('onAnnotationCreated')}
             onAnnotationUpdated={this.onCreateOrUpdateAnnotation('onAnnotationUpdated')}
             onAnnotationDeleted={this.onDeleteAnnotation}
-            onCancel={this.onCancelAnnotation} />
+            onCancel={this.onCancelAnnotation} 
+            config={this.props.config}/>
         }
 
         { this.state.selectedRelation &&

--- a/src/TextAnnotator.jsx
+++ b/src/TextAnnotator.jsx
@@ -41,9 +41,10 @@ export default class TextAnnotator extends Component {
   }
 
   componentDidMount() {
-    this.highlighter = new Highlighter(this.props.contentEl, this.props.config.formatter);
-
-    this.selectionHandler = new SelectionHandler(this.props.contentEl, this.highlighter, this.props.config.readOnly);
+    const {user, readOnly, formatter} = this.props.config
+    this.highlighter = new Highlighter(this.props.contentEl, formatter);
+    this.selectionHandler = new SelectionHandler(
+      this.props.contentEl, this.highlighter, readOnly, user);
     this.selectionHandler.on('select', this.handleSelect);
 
     this.relationsLayer = new RelationsLayer(this.props.contentEl);

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -134,7 +134,7 @@ export class Recogito {
 
   getAnnotations = () => {
     const annotations = this._app.current.getAnnotations();
-    return annotations.map(a => ({...a.underlying, creator: a.creator}));
+    return annotations.map(a => a.underlying);
   }
 
   loadAnnotations = (url, requestArgs) => fetch(url, requestArgs)
@@ -167,7 +167,7 @@ export class Recogito {
   setAnnotations = arg => {
     const annotations = arg || [];
     const webannotations = annotations.map(
-      ({web_annotation_data, creator}) => new WebAnnotation(web_annotation_data, {creator})
+      ({web_annotation_data, creator}) => new WebAnnotation({...web_annotation_data, creator})
     );
     return this._app.current.setAnnotations(webannotations);
   }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -134,7 +134,7 @@ export class Recogito {
 
   getAnnotations = () => {
     const annotations = this._app.current.getAnnotations();
-    return annotations.map(a => a.underlying);
+    return annotations.map(a => ({...a.underlying, creator: a.creator}));
   }
 
   loadAnnotations = (url, requestArgs) => fetch(url, requestArgs)
@@ -166,7 +166,9 @@ export class Recogito {
 
   setAnnotations = arg => {
     const annotations = arg || [];
-    const webannotations = annotations.map(a => new WebAnnotation(a));
+    const webannotations = annotations.map(
+      ({web_annotation_data, creator}) => new WebAnnotation(web_annotation_data, {creator})
+    );
     return this._app.current.setAnnotations(webannotations);
   }
 

--- a/src/selection/SelectionHandler.js
+++ b/src/selection/SelectionHandler.js
@@ -23,12 +23,13 @@ const contains = (containerEl, maybeChildEl) => {
 
 export default class SelectionHandler extends EventEmitter {
 
-  constructor(element, highlighter, readOnly) {
+  constructor(element, highlighter, readOnly, user) {
     super();
 
     this.el = element;
     this.highlighter = highlighter;
     this.readOnly = readOnly;
+    this.user = user;
 
     this.isEnabled = true;
 
@@ -124,7 +125,7 @@ export default class SelectionHandler extends EventEmitter {
         // Ensure that there is some annotatable node with an id to determine relative offsets
         // and is entirely inside this.el
         if (isAnnotatable && contains(this.el, commonAncestorContainer)) {
-          const stub = rangeToSelection(selectedRange, startNode);
+          const stub = rangeToSelection(selectedRange, startNode, this.user);
 
           const spans = this.highlighter.wrapRange(selectedRange);
           spans.forEach(span => span.className = 'r6o-selection');

--- a/src/selection/SelectionUtils.js
+++ b/src/selection/SelectionUtils.js
@@ -40,7 +40,7 @@ export const trimRange = range => {
   return range;
 };
 
-export const rangeToSelection = (range, startNode) => {
+export const rangeToSelection = (range, startNode, user) => {
   // A helper range from the start of the startNode to the start of the selection
   const rangeBefore = document.createRange();
 
@@ -50,7 +50,8 @@ export const rangeToSelection = (range, startNode) => {
   const quote = range.toString();
   const start = rangeBefore.toString().length;
 
-  return new Selection({ 
+  return new Selection(
+    user, { 
     selector: [{
       type: 'TextQuoteSelector',
       exact: quote


### PR DESCRIPTION
Since an annotation is created and edited by only the same person, use the creator definition of an annotation to make it editable or not.