### PR TITLE
Deselect when clicking outside the editor

### DIFF
--- a/src/TextAnnotator.jsx
+++ b/src/TextAnnotator.jsx
@@ -40,6 +40,31 @@ export default class TextAnnotator extends Component {
       this.onCancelAnnotation();
   }
 
+  deselectOnClickOutside = evt => {
+    if (this.props.contentEl.contains(evt.target)) {
+      // Handle deselecting through SelectionHandler._onMouseUp
+      // when clicking something inside the contentEl
+      return
+    }
+    // Walk up the tree to find if we're clicking somewhere outside
+    // the contentEl and clear the state and selection if it's outside
+    // the editor and the contentEl
+    let currentNode = evt.target,
+        found = false;
+    while (currentNode && !found)  {
+      const {classList} = currentNode;
+      if (!classList || !classList.contains('r6o-editor')) {
+        currentNode = currentNode.parentNode;
+      } else {
+        found = true;
+      }
+    }
+    if (!currentNode) {
+      this.clearState();
+      this.selectionHandler.clearSelection();
+    }
+  }
+
   componentDidMount() {
     const {user, readOnly, formatter} = this.props.config
     this.highlighter = new Highlighter(this.props.contentEl, formatter);
@@ -54,10 +79,12 @@ export default class TextAnnotator extends Component {
     this.relationsLayer.on('cancelDrawing', this.closeRelationsEditor);
 
     document.addEventListener('keydown', this.handleEscape);
+    document.addEventListener('mouseup', this.deselectOnClickOutside);
   }
 
   componentWillUnmount() {
     document.removeEventListener('keydown', this.handleEscape);
+    document.removeEventListener('mouseup', this.deselectOnClickOutside);
   }
 
   /**************************/

--- a/src/highlighter/Highlighter.js
+++ b/src/highlighter/Highlighter.js
@@ -1,4 +1,4 @@
-const TEXT = 3; // HTML DOM node type for text nodes
+import { TEXT_NODE } from "../utils";
 
 const RENDER_BATCH_SIZE = 100; // Number of annotations to render in one frame
 
@@ -174,7 +174,7 @@ export default class Highlighter {
     if (offset > stopOffset)
       return false;
 
-    if (node.nodeType === TEXT)
+    if (node.nodeType === TEXT_NODE)
       nodes.push(node);
 
     node = node.firstChild;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -53,3 +53,4 @@ const deflateNodeList = parents => {
 
 }
 
+export const TEXT_NODE = 3; // HTML DOM node type for text nodes


### PR DESCRIPTION
Deselect when clicking outside of the editor where the place clicked is:
1. In the annotatable dom element. The `SelectionHandler._onMouseUp` handles this as it has the context of what's being selected and clicked
2. Outside of the annotatable dom element. The `TextAnnotator.deselectOnClickOutside` handles this